### PR TITLE
Change 'data.tostring()' to 'data.tobytes()'

### DIFF
--- a/audio_utilities.py
+++ b/audio_utilities.py
@@ -1,6 +1,3 @@
-
-
-
 import math
 import sys
 import time
@@ -313,5 +310,5 @@ def save_audio_to_file(x, sample_rate, outfile='out.wav'):
         data.append(cur_samp)
     f = wave.open(outfile, 'w')
     f.setparams((1, 2, sample_rate, 0, "NONE", "Uncompressed"))
-    f.writeframes(data.tostring())
+    f.writeframes(data.tobytes())
     f.close()


### PR DESCRIPTION
Changed 'data.tostring()' to 'data.tobytes()' in function 'save_audio_to_file' in 'audio_utilities.py'. Since Python 3.2, 'tostring()' is renamed to 'tobytes', according to [the official Python Docs](https://docs.python.org/3/library/array.html#array.array.tobytes).